### PR TITLE
Fix new gig API validation and await submit

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -81,7 +81,7 @@ export default function Layout({ title, description, asiakas, children }) {
     router.reload(window.location.pathname);
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
 
     const lomake = {
@@ -100,7 +100,7 @@ export default function Layout({ title, description, asiakas, children }) {
       api_url = `https://keikat.oskarijarvelin.fi/api/new_gig`;
     }
 
-    const response = fetch(`${api_url}`, {
+    const response = await fetch(`${api_url}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/pages/api/new_gig.js
+++ b/pages/api/new_gig.js
@@ -2,7 +2,7 @@
 export default function handler(req, res) {
     const body = req.body;
 
-    if (!body.pid) {
+    if (!body.asiakasnumero) {
         return res.status(400).json({ data: "Missing Client ID" });
     }
 


### PR DESCRIPTION
## Summary
- fix client id check in `pages/api/new_gig.js`
- make `handleSubmit` asynchronous and await the POST request

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68878620ea04832294abb79b55d45240