### PR TITLE
Fix Layout prop usage on index page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -42,7 +42,7 @@ export default function Index() {
     <Layout
       title="Vittu oon keikkaa tehnyt - Oskari Järvelin"
       description="Kuvaus"
-      projekti={false}
+      asiakas={false}
     >
       <Box sx={{ ...style }}>
         <Typography


### PR DESCRIPTION
## Summary
- update `<Layout>` on the landing page to pass `asiakas` prop instead of `projekti`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68878935a45c8322aee1dfa9862ada6a