### PR TITLE
Update Emotion cache comment

### DIFF
--- a/src/createEmotionCache.js
+++ b/src/createEmotionCache.js
@@ -2,9 +2,11 @@ import createCache from '@emotion/cache';
 
 const isBrowser = typeof document !== 'undefined';
 
-// On the client side, Create a meta tag at the top of the <head> and set it as insertionPoint.
-// This assures that MUI styles are loaded first.
-// It allows developers to easily override MUI styles with other styling solutions, like CSS modules.
+// On the client side, this function looks for an existing meta tag named
+// `emotion-insertion-point` at the top of the <head> and uses it as the
+// insertion point. This assures that MUI styles are loaded first and allows
+// developers to easily override them with other styling solutions, like CSS
+// modules.
 export default function createEmotionCache() {
   let insertionPoint;
 


### PR DESCRIPTION
## Summary
- clarify that `createEmotionCache` searches for an existing `emotion-insertion-point` meta tag instead of creating one

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887894b5a408322a5de06b085515a44