### PR TITLE
Add Jest and unit tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }]
+  ]
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.js$': 'babel-jest'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -39,5 +40,11 @@
     "react-dom": "^18.2.0",
     "react-moment": "^1.1.3",
     "styled-components": "^6.1.13"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.22.20",
+    "@babel/preset-env": "^7.22.20",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0"
   }
 }

--- a/src/__tests__/functions.test.js
+++ b/src/__tests__/functions.test.js
@@ -1,0 +1,60 @@
+import { msFormatter, formatAjankohta, capitalizeFirstLetter } from '../functions';
+
+describe('msFormatter', () => {
+  test('converts milliseconds to hours string', () => {
+    expect(msFormatter(7200000)).toBe('2');
+  });
+
+  test('returns 0 for null', () => {
+    expect(msFormatter(null)).toBe(0);
+  });
+
+  test('returns 0 for undefined', () => {
+    expect(msFormatter(undefined)).toBe(0);
+  });
+});
+
+describe('formatAjankohta', () => {
+  test('single day format when dates match', () => {
+    const time = Date.parse('2024-01-01T00:00:00Z');
+    expect(formatAjankohta(time, time)).toBe('1.1.2024');
+  });
+
+  test('same month date range', () => {
+    const start = Date.parse('2024-01-01T00:00:00Z');
+    const end = Date.parse('2024-01-05T00:00:00Z');
+    expect(formatAjankohta(start, end)).toBe('1.–5.1.2024');
+  });
+
+  test('cross-month date range', () => {
+    const start = Date.parse('2024-03-31T00:00:00Z');
+    const end = Date.parse('2024-04-02T00:00:00Z');
+    expect(formatAjankohta(start, end)).toBe('31.3.–2.4.2024');
+  });
+
+  test('returns "Invalid date" for null values', () => {
+    expect(formatAjankohta(null, null)).toBe('Invalid date');
+  });
+
+  test('returns "Invalid date" for undefined values', () => {
+    expect(formatAjankohta(undefined, undefined)).toBe('Invalid date');
+  });
+});
+
+describe('capitalizeFirstLetter', () => {
+  test('capitalizes first letter of string', () => {
+    expect(capitalizeFirstLetter('hello')).toBe('Hello');
+  });
+
+  test('returns empty string when given empty string', () => {
+    expect(capitalizeFirstLetter('')).toBe('');
+  });
+
+  test('throws error for null', () => {
+    expect(() => capitalizeFirstLetter(null)).toThrow();
+  });
+
+  test('throws error for undefined', () => {
+    expect(() => capitalizeFirstLetter(undefined)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest configuration with Babel
- define dev dependencies and npm test script
- test `msFormatter`, `formatAjankohta` and `capitalizeFirstLetter`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887895e813c8322b0a7d9c1247390b8